### PR TITLE
Python datetime fix.

### DIFF
--- a/lib/fiveserver/data.py
+++ b/lib/fiveserver/data.py
@@ -228,9 +228,9 @@ class ProfileData:
                'fav_player=%s, fav_team=%s, rank=%s, '
                'points=%s, disconnects=%s, seconds_played=%s')
         params = (p.id, p.userId, p.index, p.name, p.favPlayer, p.favTeam,
-                  p.rank, p.points, p.disconnects, p.playTime.seconds,
+                  p.rank, p.points, p.disconnects, p.playTime.total_seconds,
                   p.userId, p.index, p.name, p.favPlayer, p.favTeam, p.rank,
-                  p.points, p.disconnects, p.playTime.seconds)
+                  p.points, p.disconnects, p.playTime.total_seconds)
         yield self.dbController.dbWrite(0, sql, *params)
         defer.returnValue(True)
 

--- a/lib/fiveserver/data6.py
+++ b/lib/fiveserver/data6.py
@@ -113,9 +113,9 @@ class ProfileData(data.ProfileData):
                'rank=%s, rating=%s, points=%s, '
                'disconnects=%s, seconds_played=%s, comment=%s')
         params = (p.id, p.userId, p.index, p.name, 
-                  p.rank, p.rating, p.points, p.disconnects, p.playTime.seconds,
+                  p.rank, p.rating, p.points, p.disconnects, p.playTime.total_seconds,
                   p.comment, p.userId, p.index, p.name, p.rank,
-                  p.rating, p.points, p.disconnects, p.playTime.seconds, 
+                  p.rating, p.points, p.disconnects, p.playTime.total_seconds, 
                   p.comment)
         yield self.dbController.dbWrite(0, sql, *params)
         defer.returnValue(True)

--- a/lib/fiveserver/protocol/pes5.py
+++ b/lib/fiveserver/protocol/pes5.py
@@ -263,7 +263,7 @@ class LoginService(PacketDispatcher):
                 'index':struct.pack('!B', i),
                 'id':struct.pack('!i', profile.id),
                 'name':util.padWithZeros(profile.name, 16),
-                'playTime':struct.pack('!i', profile.playTime.seconds),
+                'playTime':struct.pack('!i', profile.playTime.total_seconds),
                 'division':struct.pack('!B', 
                     self.factory.ratingMath.getDivision(profile.points)),
                 'points':struct.pack('!i', profile.points),

--- a/lib/fiveserver/protocol/pes6.py
+++ b/lib/fiveserver/protocol/pes6.py
@@ -144,7 +144,7 @@ class LoginService(RosterHandler, pes5.LoginService):
                 'name':util.padWithZeros(profile.name, 48),
                 'division':struct.pack('!B', 
                     self.factory.ratingMath.getDivision(profile.points)),
-                'playTime':struct.pack('!i', profile.playTime.seconds),
+                'playTime':struct.pack('!i', profile.playTime.total_seconds),
                 'points':struct.pack('!i', profile.points),
                 'games':struct.pack('!H', games),
                 'rating':struct.pack('!H',profile.rating),


### PR DESCRIPTION
This PR fixes upstream issue #2. As python datetime is awkward

Have a medium article about why total_seconds is what should be used here.
https://medium.com/python-pandemonium/datetime-datetime-seconds-8c76c5ace3d2

Basically... tl;dr .total_seconds function is a total, while plain .seconds function caps at 85999, essentially one full day.

I've fixed it using the issue reporter's code, so credit to him for finding the bug. I just merely implemented fix.