### PR TITLE
Update default IpDetectUri

### DIFF
--- a/etc/conf/sixserver.yaml
+++ b/etc/conf/sixserver.yaml
@@ -7,7 +7,7 @@ Comment: |
 
 ServerIP: auto
 ListenOn: ""
-IpDetectUri: "http://mapote.com/cgi-bin/ip.py"
+IpDetectUri: "http://api.ipify.org"
 
 Lobbies:
     - 'Russia'


### PR DESCRIPTION
The new URL is found to be faster and more reliable

```
http://mapote.com/cgi-bin/ip.py
0.503533 secs
0.599367 secs
0.503842 secs
```
```
http://api.ipify.org
0.481049 secs
0.516370 secs
0.483688 secs
```