### PR TITLE
Modernizing IP detection for Python 3 and recent Twisted versions

### DIFF
--- a/lib/fiveserver/config.py
+++ b/lib/fiveserver/config.py
@@ -4,7 +4,7 @@ Configuration classes for packet server
 
 
 from twisted.internet import reactor, defer
-from twisted.web import client
+from twisted.web import client, error, http
 from xml.dom import minidom
 from datetime import datetime, timedelta
 import time
@@ -12,11 +12,13 @@ import random
 import struct
 import socket
 
+from twisted.internet.threads import deferToThread
+import urllib.request
+
 from fiveserver.model import lobby, user
 from fiveserver import storagecontroller, errors, rating, log
 import yaml
 import os
-
 
 class YamlConfig:
     def __init__(self, yamlFile, newYamlFile=None):
@@ -371,10 +373,12 @@ class FiveServerConfig:
         except AttributeError:
             self.serverConfig.ServerIP = None
         if self.serverConfig.ServerIP in [None,'auto']:
-            # try to determine the WAN address
-            d = client.getPage(self.ipDetectUri.encode('utf-8'), timeout=10)
+            def fetch_ip(url):
+                with urllib.request.urlopen(url, timeout=10) as response:
+                    return response.read().decode('utf-8')
+            
+            d = deferToThread(fetch_ip, self.ipDetectUri)
         else:
-            # explicitly set in configuration file
             d = defer.succeed(self.serverConfig.ServerIP)
         d.addCallback(_setIP)
         d.addErrback(_error, retryDelay)

--- a/lib/fiveserver/config.py
+++ b/lib/fiveserver/config.py
@@ -353,7 +353,10 @@ class FiveServerConfig:
 
     def setIP(self, retryDelay=1, resetTime=True):
         def _setIP(result):
-            self.serverIP_wan = result.decode('utf-8').strip()
+            if isinstance(result, bytes):
+                self.serverIP_wan = result.decode('utf-8').strip()
+            else:
+                self.serverIP_wan = result.strip()
             if resetTime:
                 self.startDatetime = datetime.now()
             log.msg('Server IP-address: %s' % self.serverIP_wan)


### PR DESCRIPTION
This PR restores compatibility with modern Python and Twisted versions and resolves startup failures on current Debian-based systems (e.g. Debian 12 / Bookworm).

**Changes**

1. Twisted API compatibility
    Replaces the removed twisted.web.client.getPage call with a thread-based implementation using urllib.request
    wrapped in deferToThread. This preserves asynchronous behavior without blocking the Twisted reactor.
3. Python 3 type handling fix
    Adds a safe type check (isinstance(result, bytes)) before decoding the detected IP address.
    This prevents AttributeError: 'str' object has no attribute 'decode' when the response is already a string.

**Result**

- Fiveserver starts correctly on modern Linux distributions
- Compatible with current Twisted releases
- Compatible with Python 3.11–3.13
- Tested on Raspberry Pi 1B running DietPi (Debian 12).

This change does not alter existing configuration behavior and preserves automatic IP detection when ServerIP is set to auto.