### PR TITLE
pinning libs to fix ssl requests

### DIFF
--- a/pip.requirements
+++ b/pip.requirements
@@ -1,7 +1,8 @@
 mysqlclient
 PyYAML
 Twisted==20.3.0
-pyOpenSSL
+pyOpenSSL==21.0.0
+cryptography==3.4.8
 pycryptodome
-zope.interface
-service-identity
+zope.interface==5.5.2
+service-identity==21.1.0


### PR DESCRIPTION
While doing a few tests to improve the dockerfile I encounter that the admin page will fail due to some libs latest versions not being fully compatible with latest version, causing this the broken access to any ssl page

here's some logs

```
2026-05-12T18:19:23+0000 [_GenericHTTPChannelProtocol (TLSMemoryBIOProtocol),17,186.123.216.200] Unhandled Error
        Traceback (most recent call last):
          File "/usr/local/lib/python3.10/site-packages/twisted/application/app.py", line 312, in runReactorWithLogging
            reactor.run()
          File "/usr/local/lib/python3.10/site-packages/twisted/internet/base.py", line 1283, in run
            self.mainLoop()
          File "/usr/local/lib/python3.10/site-packages/twisted/internet/base.py", line 1295, in mainLoop
            self.doIteration(t)
          File "/usr/local/lib/python3.10/site-packages/twisted/internet/epollreactor.py", line 235, in doPoll
            log.callWithLogger(selectable, _drdw, selectable, fd, event)
        --- <exception caught here> ---
          File "/usr/local/lib/python3.10/site-packages/twisted/python/log.py", line 103, in callWithLogger
            return callWithContext({"system": lp}, func, *args, **kw)
          File "/usr/local/lib/python3.10/site-packages/twisted/python/log.py", line 86, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/usr/local/lib/python3.10/site-packages/twisted/python/context.py", line 122, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/usr/local/lib/python3.10/site-packages/twisted/python/context.py", line 85, in callWithContext
            return func(*args,**kw)
          File "/usr/local/lib/python3.10/site-packages/twisted/internet/posixbase.py", line 627, in _doReadOrWrite
            self._disconnectSelectable(selectable, why, inRead)
          File "/usr/local/lib/python3.10/site-packages/twisted/internet/posixbase.py", line 258, in _disconnectSelectable
            selectable.connectionLost(failure.Failure(why))
          File "/usr/local/lib/python3.10/site-packages/twisted/internet/tcp.py", line 327, in connectionLost
            protocol.connectionLost(reason)
          File "/usr/local/lib/python3.10/site-packages/twisted/protocols/tls.py", line 397, in connectionLost
            self._tlsConnection.bio_shutdown()
          File "/usr/local/lib/python3.10/site-packages/twisted/protocols/policies.py", line 114, in __getattr__
            return getattr(self.transport, name)
        builtins.AttributeError: 'NoneType' object has no attribute '_tlsConnection'
```

Besides that, I will be working on doing some tests to migrate to latest version of python later on since python 3.10 (latest version I was able to use to make work current twisted version) wiill be losing support by october 2026

https://devguide.python.org/versions/#status-of-python-versions