### PR TITLE
Fix settings not being saved

### DIFF
--- a/lib/fiveserver/protocol/pes5.py
+++ b/lib/fiveserver/protocol/pes5.py
@@ -442,7 +442,9 @@ class LoginService(PacketDispatcher):
         defer.returnValue(None)
 
     def do_3088(self, pkt):
-        if pkt.data[2] == b'\3':
+        # When accessing one specific element of a bytes string in Python3,
+        # you get a number instead of a bytes object. So we need to check for the value 3 instead of b'\x03'.
+        if pkt.data[2] == 3:
             # update settings
             settings1 = zlib.compress(pkt.data)
             self._user.profile.settings.settings1 = settings1


### PR DESCRIPTION
Fix mentioned by @pedroh14 on #31 investigated a bit and now byte strings when being access by one specific index will return integer instead of byte string object, besides that i did an extra check and didnt found any other case like this